### PR TITLE
UserInterface: extended G10 with 0 at axis parameter

### DIFF
--- a/src/UI/UserInterface.cpp
+++ b/src/UI/UserInterface.cpp
@@ -3792,7 +3792,7 @@ namespace UI
 
 			case evSetAxesOffsetToCurrent:
 				{
-					SerialIo::Sendf("G10 L20 P%s %c\n", currentWCSPress.GetSParam(), bp.GetSParam()[0]);
+					SerialIo::Sendf("G10 L20 P%s %c0\n", currentWCSPress.GetSParam(), bp.GetSParam()[0]);
 				}
 				break;
 


### PR DESCRIPTION
Fixes https://github.com/Duet3D/Diabase/issues/6